### PR TITLE
Add timezone update feature

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -7,6 +7,7 @@ import {
   joinBoard as dbJoinBoard,
   getBoard,
   toggleAvailability as dbToggleAvailability,
+  updateUserTimezone as dbUpdateUserTimezone,
 } from '@/lib/db';
 import { setUserCookie } from '@/lib/auth';
 import { revalidatePath } from 'next/cache';
@@ -92,5 +93,10 @@ export async function toggleAvailability(boardId: string, userId: string, timeSl
     await dbToggleAvailability(boardId, userId, dayOfWeek, slotIndex, isAvailable);
     // In a real-time app, you'd use a service like Firebase Realtime DB or a WebSocket
     // to push updates to clients. For this example, revalidation is a simpler approach.
+    revalidatePath(`/board/${boardId}`);
+}
+
+export async function updateTimezone(boardId: string, userId: string, timezone: string) {
+    await dbUpdateUserTimezone(boardId, userId, timezone);
     revalidatePath(`/board/${boardId}`);
 }

--- a/src/components/board/BoardClient.tsx
+++ b/src/components/board/BoardClient.tsx
@@ -1,14 +1,18 @@
 'use client';
 
 import type { Board } from '@/lib/types';
-import { useState, useTransition } from 'react';
+import { useState, useTransition, useEffect } from 'react';
 import UserRoster from './UserRoster';
 import CalendarGrid from './CalendarGrid';
-import { toggleAvailability as toggleAvailabilityAction } from '@/app/actions';
+import { toggleAvailability as toggleAvailabilityAction, updateTimezone as updateTimezoneAction } from '@/app/actions';
 
 export default function BoardClient({ board, currentUserId }: { board: Board; currentUserId: string }) {
   const [boardState, setBoardState] = useState(board);
   const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    setBoardState(board);
+  }, [board]);
 
   const handleToggleAvailability = (timeSlot: string, isAvailable: boolean) => {
     // Optimistic update
@@ -35,15 +39,20 @@ export default function BoardClient({ board, currentUserId }: { board: Board; cu
     });
   };
 
-  // The board state can become stale if another user joins.
-  // We can update it when the component re-renders with new props.
-  if (board.id !== boardState.id || board.users.length !== boardState.users.length) {
-      setBoardState(board);
-  }
+  const handleTimezoneChange = (tz: string) => {
+    const newUsers = boardState.users.map((u) =>
+      u.id === currentUserId ? { ...u, timezone: tz } : u
+    );
+    setBoardState({ ...boardState, users: newUsers });
+
+    startTransition(async () => {
+      await updateTimezoneAction(board.id, currentUserId, tz);
+    });
+  };
 
   return (
     <div className="flex flex-col lg:flex-row min-h-screen">
-      <UserRoster board={boardState} />
+      <UserRoster board={boardState} currentUserId={currentUserId} onTimezoneChange={handleTimezoneChange} />
       <main className="flex-1 p-2 sm:p-4 md:p-6">
         <CalendarGrid
           availability={boardState.availability}

--- a/src/components/board/UserRoster.tsx
+++ b/src/components/board/UserRoster.tsx
@@ -1,15 +1,24 @@
 import type { Board } from '@/lib/types';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import { Users, Clock } from 'lucide-react';
 import { ScrollArea } from '../ui/scroll-area';
 import { Logo } from '../icons/Logo';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 
-export default function UserRoster({ board }: { board: Board }) {
+type Props = {
+  board: Board;
+  currentUserId: string;
+  onTimezoneChange: (tz: string) => void;
+};
+export default function UserRoster({ board, currentUserId, onTimezoneChange }: Props) {
   const copyToClipboard = () => {
     navigator.clipboard.writeText(board.id);
     // You could add a toast notification here for feedback
   };
+
+  const timezones = typeof Intl.supportedValuesOf === 'function'
+    ? Intl.supportedValuesOf('timeZone')
+    : ['UTC'];
 
   return (
     <aside className="lg:w-80 lg:h-screen lg:border-r border-b lg:border-b-0">
@@ -47,7 +56,22 @@ export default function UserRoster({ board }: { board: Board }) {
                         <p className="font-semibold">{user.name}</p>
                         <p className="text-sm text-muted-foreground flex items-center gap-1.5">
                             <Clock className="w-3 h-3" />
-                            {user.timezone}
+                            {user.id === currentUserId ? (
+                              <Select value={user.timezone} onValueChange={onTimezoneChange}>
+                                <SelectTrigger className="w-[160px] h-8">
+                                  <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent className="max-h-64">
+                                  {timezones.map((tz) => (
+                                    <SelectItem key={tz} value={tz}>
+                                      {tz}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            ) : (
+                              <span>{user.timezone}</span>
+                            )}
                         </p>
                     </div>
                     </div>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -134,3 +134,27 @@ export async function toggleAvailability(
     if (error) throw new Error(error.message);
   }
 }
+
+/**
+ * Update a user's timezone on a board.
+ */
+export async function updateUserTimezone(
+  boardCode: string,
+  userId: string,
+  timezone: string
+): Promise<void> {
+  const { data: board } = await supabase
+    .from('boards')
+    .select('id')
+    .eq('code', boardCode)
+    .single();
+
+  if (!board) throw new Error('Board not found');
+
+  const { error } = await supabase
+    .from('board_users')
+    .update({ timezone })
+    .match({ board_id: board.id, id: userId });
+
+  if (error) throw new Error(error.message);
+}


### PR DESCRIPTION
## Summary
- allow updating user timezone in db and server actions
- optimistically update timezone on the board
- expose timezone dropdown in roster

## Testing
- `npm run typecheck`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687e8be3a7908322994e0c885c70797a