### PR TITLE
Improve board scrolling

### DIFF
--- a/src/components/board/CalendarGrid.tsx
+++ b/src/components/board/CalendarGrid.tsx
@@ -61,6 +61,7 @@ export default function CalendarGrid({
   });
 
   const TIME_COL_WIDTH = 80; // width in px for sticky time columns
+  const HEADER_HEIGHT = 40; // height in px for the top header rows
   const columnStyle = {
     gridTemplateColumns: `${timezones
       .map(() => `${TIME_COL_WIDTH}px`)
@@ -74,7 +75,7 @@ export default function CalendarGrid({
         {timezones.map((tz, idx) => (
           <div
             key={tz}
-            className="sticky top-0 z-20 p-2 text-center font-semibold bg-muted border-b border-r"
+            className="sticky top-0 z-20 p-2 text-center font-semibold bg-muted border-b border-r border-border/70 h-10"
             style={{ left: idx * TIME_COL_WIDTH }}
           >
             {timezoneAbbr(tz)}
@@ -84,7 +85,8 @@ export default function CalendarGrid({
         {DAYS.map((day) => (
           <div
             key={day}
-            className="sticky top-0 z-10 p-2 text-center font-semibold bg-muted border-b border-r"
+            className="sticky z-10 p-2 text-center font-semibold bg-muted border-b border-r border-border/70 h-10"
+            style={{ top: HEADER_HEIGHT }}
           >
             {day}
           </div>
@@ -97,7 +99,7 @@ export default function CalendarGrid({
             {timezones.map((_, tzIdx) => (
               <div
                 key={`${tzIdx}-${timeIndex}`}
-                className="p-2 text-right text-xs font-mono bg-muted border-r whitespace-nowrap sticky z-10"
+                className="p-2 text-right text-xs font-mono bg-muted border-r border-border/70 whitespace-nowrap sticky z-10"
                 style={{ left: tzIdx * TIME_COL_WIDTH }}
               >
                 {timeLabelsByTz[tzIdx][timeIndex]}

--- a/src/components/board/CalendarGrid.tsx
+++ b/src/components/board/CalendarGrid.tsx
@@ -60,18 +60,22 @@ export default function CalendarGrid({
     });
   });
 
+  const TIME_COL_WIDTH = 80; // width in px for sticky time columns
   const columnStyle = {
-    gridTemplateColumns: `${timezones.map(() => 'max-content').join(' ')} repeat(7,minmax(100px,1fr))`,
+    gridTemplateColumns: `${timezones
+      .map(() => `${TIME_COL_WIDTH}px`)
+      .join(' ')} repeat(7,minmax(100px,1fr))`,
   } as React.CSSProperties;
 
   return (
     <div className="relative overflow-auto shadow-lg rounded-lg bg-card border">
         <div className="grid" style={columnStyle}>
         {/* Header for Timezone Abbreviations */}
-        {timezones.map((tz) => (
+        {timezones.map((tz, idx) => (
           <div
             key={tz}
             className="sticky top-0 z-20 p-2 text-center font-semibold bg-muted border-b border-r"
+            style={{ left: idx * TIME_COL_WIDTH }}
           >
             {timezoneAbbr(tz)}
           </div>
@@ -80,7 +84,7 @@ export default function CalendarGrid({
         {DAYS.map((day) => (
           <div
             key={day}
-            className="sticky top-0 z-10 p-2 text-center font-semibold bg-muted border-b"
+            className="sticky top-0 z-10 p-2 text-center font-semibold bg-muted border-b border-r"
           >
             {day}
           </div>
@@ -93,7 +97,8 @@ export default function CalendarGrid({
             {timezones.map((_, tzIdx) => (
               <div
                 key={`${tzIdx}-${timeIndex}`}
-                className="p-2 text-right text-xs font-mono bg-muted border-r whitespace-nowrap"
+                className="p-2 text-right text-xs font-mono bg-muted border-r whitespace-nowrap sticky z-10"
+                style={{ left: tzIdx * TIME_COL_WIDTH }}
               >
                 {timeLabelsByTz[tzIdx][timeIndex]}
               </div>

--- a/src/components/board/TimeSlotCell.tsx
+++ b/src/components/board/TimeSlotCell.tsx
@@ -39,7 +39,7 @@ export default function TimeSlotCell({
         <TooltipTrigger asChild>
           <div
             onClick={handleClick}
-            className="h-10 border-b border-r flex items-center justify-center cursor-pointer transition-all duration-200 ease-in-out relative hover:ring-2 hover:ring-primary hover:z-10"
+            className="h-10 border-b border-r border-border/70 flex items-center justify-center cursor-pointer transition-all duration-200 ease-in-out relative hover:ring-2 hover:ring-primary hover:z-10"
             style={{ backgroundColor }}
           >
             {isCurrentUserAvailable && (


### PR DESCRIPTION
## Summary
- freeze timezone columns so time labels stay visible
- show borders more clearly on grid cells

## Testing
- `npm run lint` *(fails: interactive config prompt)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6882e0adc7108322874dcca06b8a7ccc